### PR TITLE
[Do Not Merge] Add Shared Themeing Functionality

### DIFF
--- a/js/template.js
+++ b/js/template.js
@@ -236,8 +236,8 @@ array, declare, kernel, lang, Evented, Deferred, string, domClass, all, esriConf
                 esriConfig.defaults.io.proxyUrl = this.config.proxyurl;
                 esriConfig.defaults.io.alwaysUseProxy = false;
             }
-            // add opendatadev.arcgis.com to corsEnabledServers in config, to allow calls to v2 API
-            esriConfig.defaults.io.corsEnabledServers.push("opendatadev.arcgis.com");
+            // add opendata.arcgis.com to corsEnabledServers in config, to allow calls to v2 API
+            esriConfig.defaults.io.corsEnabledServers.push("opendata.arcgis.com");
         },
         _checkSignIn: function () {
             var deferred, signedIn, oAuthInfo;
@@ -332,10 +332,10 @@ array, declare, kernel, lang, Evented, Deferred, string, domClass, all, esriConf
           var requestUrl;
           switch (status.status) {
             case "siteId":
-              requestUrl = "https://opendatadev.arcgis.com/api/v2/sites/" + status.output;
+              requestUrl = "https://opendata.arcgis.com/api/v2/sites/" + status.output;
               break;
             case "domain":
-              requestUrl = "https://opendatadev.arcgis.com/api/v2/sites?filter%5Burl%5D=" + status.output;
+              requestUrl = "https://opendata.arcgis.com/api/v2/sites?filter%5Burl%5D=" + status.output;
               break;
             case "appId":
               break;


### PR DESCRIPTION
Opening this to discuss how to bring shared themeing into app templates.
# Shared Themes
### Concept

The purpose of this forked repo is to streamline the process for developers to inherit theming from parent applications to child applications, and fulfill the shared-theme component of hub-ready apps. An example app and attached docs will allow internal Esri developers (and eventually Citizens) to create hub-ready applications in terms of shared-theming, whether they are starting from scratch or looking to make an existing app hub-ready.
### Walkthrough

---
#### Observe the example site
1. Clone this repo
2. Run http-server from the directory (download http-server if you do not have it on your machine)
   - Another option is to run “python -m SimpleHTTPServer 8000” from the directory with the index.html file.
3. Open up your locally hosted page and observe the example site, adding "/?theme=580".

```
e.g. - http://127.0.0.1:8080/?theme=580
```

Working sites ids to use in the query string (http://127.0.0.1:8080/?theme=9591)
-   9593
-   9594
-   9595

An additional option to adjust the mixed-in configuration include urls (against the open data v2 API). Working urls to use pre-query string (indicate use with ?theme=current) [need to be enabled in /etc/hosts file]
-   logotesting2.dcdev.opendata.arcgis.com
-   logotesting3.dcdev.opendata.arcgis.com
-   logotesting4.dcdev.opendata.arcgis.com

```
e.g. - logotesting2.dcdev.opendata.arcgis.com:8080/?theme=current
```

Another option is adjust the config parameters of an existing application on ArcGIS Online. Working appIds (configs available for viewing in the Configuration Parameters section of the "settings" tab of the related appId)

```
e.g. - http://127.0.0.1:8080/?appid=06f0c9022dc6411598babb9cdbc768fc
```
-   5aab4b150da3428289391ada56d7eaad
-   06f0c9022dc6411598babb9cdbc768fc
-   4d06775fbd5a4ae5bffe34ce5b37255a
  - http://dcdev.maps.arcgis.com/home/item.html?id=4d06775fbd5a4ae5bffe34ce5b37255a#settings
